### PR TITLE
Feature: delayed input update

### DIFF
--- a/streamlit_datalist/__init__.py
+++ b/streamlit_datalist/__init__.py
@@ -1,7 +1,9 @@
-import streamlit.components.v1 as components
-import streamlit as st
 import os
+from typing import Optional
+
 import pandas as pd
+import streamlit as st
+import streamlit.components.v1 as components
 
 _RELEASE = True
 
@@ -21,10 +23,10 @@ else:
     )
 
 
-def stDatalist(label:str, options:list, index:int=None, key=None, disabled:bool=False):
+def stDatalist(label:str, options:list, index:int=None, key=None, disabled:bool=False, delay: Optional[int] = None):
     def_val = options[index] if index!=None else None
     react_val = def_val
-    return_vals = _streamlit_datalist(label=label, options=options, def_val=def_val, key=key, widget_disabled=disabled)
+    return_vals = _streamlit_datalist(label=label, options=options, def_val=def_val, key=key, widget_disabled=disabled, delay=delay)
 
     if return_vals: react_val = return_vals[0]
 
@@ -52,8 +54,12 @@ if not _RELEASE:
 
     dis_but = st.checkbox('Disable datalist',value=False)
     my_sel1 = stDatalist('This datalist is...', options=data, index=u_ind, key='data', disabled=dis_but)
+    
+    st.caption('Datalist with delay enabled')
+    my_sel2 = stDatalist('This datalist is...', options=data, index=u_ind, key='data_with_delay', disabled=dis_but, delay=300)
 
     st.selectbox('Native element', data, index=u_ind, key='hi', disabled=True)
 
     with cont1:
         st.write('The value you selected is: ', my_sel1)
+        st.write('The value you selected in the datalist with delay is: ', my_sel2)

--- a/streamlit_datalist/__init__.py
+++ b/streamlit_datalist/__init__.py
@@ -1,9 +1,7 @@
-import os
-from typing import Optional
-
-import pandas as pd
-import streamlit as st
 import streamlit.components.v1 as components
+import streamlit as st
+import os
+import pandas as pd
 
 _RELEASE = True
 
@@ -23,24 +21,10 @@ else:
     )
 
 
-def stDatalist(
-    label: str,
-    options: list,
-    index: Optional[int] = None,
-    key: Optional[str] = None,
-    disabled: bool = False,
-    delay: Optional[int] = None
-):
+def stDatalist(label:str, options:list, index:int=None, key=None, disabled:bool=False):
     def_val = options[index] if index!=None else None
     react_val = def_val
-    return_vals = _streamlit_datalist(
-        label=label,
-        options=options,
-        def_val=def_val,
-        key=key,
-        widget_disabled=disabled,
-        delay=delay
-    )
+    return_vals = _streamlit_datalist(label=label, options=options, def_val=def_val, key=key, widget_disabled=disabled)
 
     if return_vals: react_val = return_vals[0]
 
@@ -67,7 +51,7 @@ if not _RELEASE:
     def_sel = 'Default_value'
 
     dis_but = st.checkbox('Disable datalist',value=False)
-    my_sel1 = stDatalist('This datalist is...', options=data, index=u_ind, key='data', disabled=dis_but, delay=300)
+    my_sel1 = stDatalist('This datalist is...', options=data, index=u_ind, key='data', disabled=dis_but)
 
     st.selectbox('Native element', data, index=u_ind, key='hi', disabled=True)
 

--- a/streamlit_datalist/__init__.py
+++ b/streamlit_datalist/__init__.py
@@ -1,7 +1,9 @@
-import streamlit.components.v1 as components
-import streamlit as st
 import os
+from typing import Optional
+
 import pandas as pd
+import streamlit as st
+import streamlit.components.v1 as components
 
 _RELEASE = True
 
@@ -21,10 +23,24 @@ else:
     )
 
 
-def stDatalist(label:str, options:list, index:int=None, key=None, disabled:bool=False):
+def stDatalist(
+    label: str,
+    options: list,
+    index: Optional[int] = None,
+    key: Optional[str] = None,
+    disabled: bool = False,
+    delay: Optional[int] = None
+):
     def_val = options[index] if index!=None else None
     react_val = def_val
-    return_vals = _streamlit_datalist(label=label, options=options, def_val=def_val, key=key, widget_disabled=disabled)
+    return_vals = _streamlit_datalist(
+        label=label,
+        options=options,
+        def_val=def_val,
+        key=key,
+        widget_disabled=disabled,
+        delay=delay
+    )
 
     if return_vals: react_val = return_vals[0]
 
@@ -51,7 +67,7 @@ if not _RELEASE:
     def_sel = 'Default_value'
 
     dis_but = st.checkbox('Disable datalist',value=False)
-    my_sel1 = stDatalist('This datalist is...', options=data, index=u_ind, key='data', disabled=dis_but)
+    my_sel1 = stDatalist('This datalist is...', options=data, index=u_ind, key='data', disabled=dis_but, delay=300)
 
     st.selectbox('Native element', data, index=u_ind, key='hi', disabled=True)
 

--- a/streamlit_datalist/frontend/src/streamlit_datalist.tsx
+++ b/streamlit_datalist/frontend/src/streamlit_datalist.tsx
@@ -1,34 +1,23 @@
-import React, { ReactNode } from "react";
 import {
-  ComponentProps,
   Streamlit,
   StreamlitComponentBase,
   withStreamlitConnection,
-} from "streamlit-component-lib";
+} from "streamlit-component-lib"
+import React, { ReactNode } from "react"
 
 class StreamlitDatalist extends StreamlitComponentBase {
-  public state = { selection: null, isFocused: false, value: '' }
-
-  constructor(props: ComponentProps) {
-    super(props);
-    this.state = { selection: null, isFocused: false, value: '' }
-    this._updateInputValue = this._updateInputValue.bind(this)
-    this._handleKeyPress = this._handleKeyPress.bind(this)
-    this._onFocus = this._onFocus.bind(this)
-    this._onBlur = this._onBlur.bind(this)
-    this._debounce = this._debounce.bind(this)
-  }
+  public state = { selection: null, isFocused: false , value: ''}
 
   public render = (): ReactNode => {
-    const { options, label, def_val, widget_disabled } = this.props.args
-
+    const { options, label, def_val, widget_disabled} = this.props.args
+    
     var i = 0
     const options_html = []
-    for (let option of options) {
-      options_html.push(<option value={option} id={option} key={i} />);
-      i += 1;
+    for (let option of options){
+      options_html.push(<option value={option} id={option} key={i}/>);
+      i+=1;
     }
-
+    
     const { theme } = this.props
     const styleLabel: React.CSSProperties = {}
     const styleInput: React.CSSProperties = {}
@@ -60,28 +49,29 @@ class StreamlitDatalist extends StreamlitComponentBase {
       styleInput.outline = '0px'
     }
 
-    if (widget_disabled === true) {
+    if (widget_disabled===true){
       styleInput.color = "rgba(120,120,120,0.65)"
       styleLabel.color = "rgba(120,120,120,0.65)"
     }
 
     return (
       <span>
-        <label style={styleLabel}> {label} <br /> </label>
-        <input style={styleInput}
-          list="datalist-datalist"
-          name="datalist"
-          id="datalist"
-          defaultValue={def_val}
-          onChange={(this.props.args.delay === null) ? (event) => { } : this._debounce(this._updateInputValue)}
-          onKeyDown={this._handleKeyPress}
-          onFocus={this._onFocus}
-          onBlur={this._onBlur}
-          key={def_val}
-          disabled={widget_disabled}
-          autoComplete='off'
-        />
+        <label style = {styleLabel}> {label} <br/> </label>
+        <input style = {styleInput}
+              list="datalist-datalist" 
+              name="datalist" 
+              id="datalist" 
+              defaultValue = {def_val}
+              // onChange = {this._updateInputValue}
+              onKeyDown = {this._handleKeyPress}
+              onFocus={this._onFocus}
+              onBlur={this._onBlur}
+              key = {def_val}
+              disabled = {widget_disabled}
+              autoComplete = 'off'
 
+              />
+        
         <datalist id="datalist-datalist" className='rowWid'>
           {options_html}
         </datalist>
@@ -89,29 +79,20 @@ class StreamlitDatalist extends StreamlitComponentBase {
     )
   }
 
-  private _debounce = (fn: (event: any) => void) => {
-    let timeoutId: ReturnType<typeof setTimeout>;
-    const delay: number = this.props.args.delay;
-    return function (event: any) {
-      event.persist();
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => fn(event), delay);
-    };
-  };
-
-  private _updateInputValue(event: any) {
-    if (event.target.value === '') {
+  private _updateInputValue(event:any) {
+    if (event.target.value===''){
       Streamlit.setComponentValue([null])
-    } else {
+    }else{
       Streamlit.setComponentValue([event.target.value])
     }
   }
 
-  private _handleKeyPress = (event: any) => {
-    if (event.key === 'Enter') {
-      if (event.target.value === '') {
+
+  private _handleKeyPress = (event:any) => {
+    if(event.key === 'Enter'){
+      if (event.target.value===''){
         Streamlit.setComponentValue([null])
-      } else {
+      }else{
         Streamlit.setComponentValue([event.target.value])
       }
     }
@@ -121,11 +102,11 @@ class StreamlitDatalist extends StreamlitComponentBase {
     this.setState({ isFocused: true })
   }
 
-  private _onBlur = (event: any): void => {
+  private _onBlur = (event:any): void => {
     this.setState({ isFocused: false })
-    if (event.target.value === '') {
+    if (event.target.value===''){
       Streamlit.setComponentValue([null])
-    } else {
+    }else{
       Streamlit.setComponentValue([event.target.value])
     }
   }

--- a/streamlit_datalist/frontend/src/streamlit_datalist.tsx
+++ b/streamlit_datalist/frontend/src/streamlit_datalist.tsx
@@ -1,23 +1,34 @@
+import React, { ReactNode } from "react";
 import {
+  ComponentProps,
   Streamlit,
   StreamlitComponentBase,
   withStreamlitConnection,
-} from "streamlit-component-lib"
-import React, { ReactNode } from "react"
+} from "streamlit-component-lib";
 
 class StreamlitDatalist extends StreamlitComponentBase {
-  public state = { selection: null, isFocused: false , value: ''}
+  public state = { selection: null, isFocused: false, value: '' }
+
+  constructor(props: ComponentProps) {
+    super(props);
+    this.state = { selection: null, isFocused: false, value: '' }
+    this._updateInputValue = this._updateInputValue.bind(this)
+    this._handleKeyPress = this._handleKeyPress.bind(this)
+    this._onFocus = this._onFocus.bind(this)
+    this._onBlur = this._onBlur.bind(this)
+    this._debounce = this._debounce.bind(this)
+  }
 
   public render = (): ReactNode => {
-    const { options, label, def_val, widget_disabled} = this.props.args
-    
+    const { options, label, def_val, widget_disabled } = this.props.args
+
     var i = 0
     const options_html = []
-    for (let option of options){
-      options_html.push(<option value={option} id={option} key={i}/>);
-      i+=1;
+    for (let option of options) {
+      options_html.push(<option value={option} id={option} key={i} />);
+      i += 1;
     }
-    
+
     const { theme } = this.props
     const styleLabel: React.CSSProperties = {}
     const styleInput: React.CSSProperties = {}
@@ -49,29 +60,28 @@ class StreamlitDatalist extends StreamlitComponentBase {
       styleInput.outline = '0px'
     }
 
-    if (widget_disabled===true){
+    if (widget_disabled === true) {
       styleInput.color = "rgba(120,120,120,0.65)"
       styleLabel.color = "rgba(120,120,120,0.65)"
     }
 
     return (
       <span>
-        <label style = {styleLabel}> {label} <br/> </label>
-        <input style = {styleInput}
-              list="datalist-datalist" 
-              name="datalist" 
-              id="datalist" 
-              defaultValue = {def_val}
-              // onChange = {this._updateInputValue}
-              onKeyDown = {this._handleKeyPress}
-              onFocus={this._onFocus}
-              onBlur={this._onBlur}
-              key = {def_val}
-              disabled = {widget_disabled}
-              autoComplete = 'off'
+        <label style={styleLabel}> {label} <br /> </label>
+        <input style={styleInput}
+          list="datalist-datalist"
+          name="datalist"
+          id="datalist"
+          defaultValue={def_val}
+          onChange={(this.props.args.delay === null) ? (event) => { } : this._debounce(this._updateInputValue)}
+          onKeyDown={this._handleKeyPress}
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
+          key={def_val}
+          disabled={widget_disabled}
+          autoComplete='off'
+        />
 
-              />
-        
         <datalist id="datalist-datalist" className='rowWid'>
           {options_html}
         </datalist>
@@ -79,20 +89,29 @@ class StreamlitDatalist extends StreamlitComponentBase {
     )
   }
 
-  private _updateInputValue(event:any) {
-    if (event.target.value===''){
+  private _debounce = (fn: (event: any) => void) => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const delay: number = this.props.args.delay;
+    return function (event: any) {
+      event.persist();
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => fn(event), delay);
+    };
+  };
+
+  private _updateInputValue(event: any) {
+    if (event.target.value === '') {
       Streamlit.setComponentValue([null])
-    }else{
+    } else {
       Streamlit.setComponentValue([event.target.value])
     }
   }
 
-
-  private _handleKeyPress = (event:any) => {
-    if(event.key === 'Enter'){
-      if (event.target.value===''){
+  private _handleKeyPress = (event: any) => {
+    if (event.key === 'Enter') {
+      if (event.target.value === '') {
         Streamlit.setComponentValue([null])
-      }else{
+      } else {
         Streamlit.setComponentValue([event.target.value])
       }
     }
@@ -102,11 +121,11 @@ class StreamlitDatalist extends StreamlitComponentBase {
     this.setState({ isFocused: true })
   }
 
-  private _onBlur = (event:any): void => {
+  private _onBlur = (event: any): void => {
     this.setState({ isFocused: false })
-    if (event.target.value===''){
+    if (event.target.value === '') {
       Streamlit.setComponentValue([null])
-    }else{
+    } else {
       Streamlit.setComponentValue([event.target.value])
     }
   }

--- a/streamlit_datalist/frontend/src/streamlit_datalist.tsx
+++ b/streamlit_datalist/frontend/src/streamlit_datalist.tsx
@@ -1,15 +1,15 @@
+import React, { ReactNode } from "react"
 import {
   Streamlit,
   StreamlitComponentBase,
   withStreamlitConnection,
 } from "streamlit-component-lib"
-import React, { ReactNode } from "react"
 
 class StreamlitDatalist extends StreamlitComponentBase {
   public state = { selection: null, isFocused: false , value: ''}
 
   public render = (): ReactNode => {
-    const { options, label, def_val, widget_disabled} = this.props.args
+    const { options, label, def_val, widget_disabled, delay} = this.props.args
     
     var i = 0
     const options_html = []
@@ -62,7 +62,7 @@ class StreamlitDatalist extends StreamlitComponentBase {
               name="datalist" 
               id="datalist" 
               defaultValue = {def_val}
-              // onChange = {this._updateInputValue}
+              onChange={(this.props.args.delay === null) ? (event) => { } : this._debounce(this._updateInputValue, delay)}
               onKeyDown = {this._handleKeyPress}
               onFocus={this._onFocus}
               onBlur={this._onBlur}
@@ -87,6 +87,14 @@ class StreamlitDatalist extends StreamlitComponentBase {
     }
   }
 
+  private _debounce = (fn: (event: any) => void, delay: number) => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    return function (event: any) {
+      event.persist();
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => fn(event), delay);
+    };
+  };
 
   private _handleKeyPress = (event:any) => {
     if(event.key === 'Enter'){


### PR DESCRIPTION
I used a technique called "debouncing" to delay the `_updateInputValue` method to wait with the update of the component's value until the user hasn't typed for some some delay time `delay`. This way the user does not have to press `enter` to update the value and the streamlit app is not overstrained by constant updates of the component.

The original behavior, where the component value is only updated on `enter` is maintained when setting the `delay_` argument to `None` (default).

 When setting the `delay` argument to some integer >= 0 (delay in ms) the component is only updated when the user hasn't input text for some time specified by `delay`.
